### PR TITLE
fix(dns): don't use HOSTNAME variable

### DIFF
--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -90,7 +90,7 @@ func processFile(file string, force bool) error {
 		log.Printf("Current IP %s matches IP for %s, no work needed\n", currentIP, config.Address)
 		return nil
 	}
-	log.Printf("Need to update IP for %s to %s from %s\n", config.HostName, currentIP, dnsIPs)
+	log.Printf("Need to update IP for %s to %s from %s\n", config.Record, currentIP, dnsIPs)
 	var updater resolver.Updater
 	switch strings.ToLower(config.Type) {
 	case "cloudflare":
@@ -105,7 +105,7 @@ func processFile(file string, force bool) error {
 		return fmt.Errorf("could not initialize updater based on type \"%s\"", config.Type)
 	}
 
-	err = updater.Update(context.TODO(), currentIP, config.HostName, config.ZoneID)
+	err = updater.Update(context.TODO(), currentIP, config.Record, config.ZoneID)
 	if err != nil {
 		return fmt.Errorf("failed to update IP address: %s", err)
 	}

--- a/internal/util/config.go
+++ b/internal/util/config.go
@@ -9,7 +9,7 @@ type Config struct {
 	Address            string `mapstructure:"ADDRESS"`
 	Type               string `mapstructure:"TYPE"`
 	CloudflareApiToken string `mapstructure:"CLOUDFLARE_API_TOKEN"`
-	HostName           string `mapstructure:"HOSTNAME"`
+	Record             string `mapstructure:"RECORD"`
 }
 
 func LoadConfig(path string, file string) (Config, error) {


### PR DESCRIPTION
The `HOSTNAME` variable is already used, so we don't want to use that. Change
to `RECORD` to align with what's actually being updated.
